### PR TITLE
fix(main): index argv, use sys.exit()

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -11,14 +11,14 @@ def docs():
         for line in f.readlines():
             print(line)
         
-        quit()
+        sys.exit()
 
 def main(argv):
     init()
     if len(argv) <= 1:
         docs()
     
-    if argv[1] == "-h" or argv == "--help":
+    if argv[1] == "-h" or argv[1] == "--help":
         docs()
         
     url = argv[1]


### PR DESCRIPTION
**Summary**
* `quit()` and its alias `exit()` should not be used in production code - they are imported by the `site` module and should only be used in the REPL.
See https://docs.python.org/2/library/constants.html#constants-added-by-the-site-module which recommends against usage of said functions in production code
* fix small bug where argv was not being indexed (comparing a list to a string is never truthy)

Was originally going to separate these into two PRs, but they were so small that I didn't really think it'd be worth doing so.